### PR TITLE
[fixes #24] Adds device registration and listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .logs
 vendor-composer
+*.swp

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -48,5 +48,15 @@ CREATE TABLE `login_data` (
 
 CREATE TABLE `user_devices` (
   `device_id` CHAR(12) PRIMARY KEY,
-  `user_id` BIGINT UNSIGNED NOT NULL REFERENCES `login_data`(`id`) MATCH SIMPLE
+  `user_id` BIGINT UNSIGNED NOT NULL REFERENCES `login_data`(`id`) MATCH SIMPLE,
+  `device_type_id` INT NOT NULL REFERENCES `device_type`(`device_type_id`) MATCH SIMPLE,
+  `group_id` VARCHAR(256) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `device_type` (
+  `device_type_id` INT PRIMARY KEY,
+  `name` VARCHAR(128) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `device_type`(`device_type_id`, `name`) VALUES
+  (1, 'Vehicle');

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -8,6 +8,8 @@ RewriteRule ^api/(.*)$ /api-route.php?path=$1 [qsappend]
 
 RewriteRule ^vendor-composer/ - [F]
 
+RewriteRule ^lib/ - [F]
+
 <FilesMatch "config\.php|composer\.(json|lock)">
   Order Deny,Allow
   Deny from All

--- a/www/api-route.php
+++ b/www/api-route.php
@@ -11,6 +11,7 @@
     $r->get(v1('ping'), mk_handler('ping'));
     $r->post(v1('signin'), mk_handler('auth'));
     $r->get(v1('verify'), mk_handler('verify'));
+    $r->post(v1('{user}/device'), mk_handler('new_device'));
   };
 
   // render produces a HTTP response out of an API response. This includes

--- a/www/api-route.php
+++ b/www/api-route.php
@@ -15,7 +15,7 @@
     if ($err != null) {
       $errmsg = ": $err";
     }
-    return new ApiError("Internal Server Error$errmsg", 503);
+    return new ApiError("Internal Server Error", 503);
   }
 
   // routing_table constructs the API endpoints and configures their handlers

--- a/www/api/auth.php
+++ b/www/api/auth.php
@@ -1,23 +1,22 @@
 <?php
+// TODO: need to swap our stuff to an autoloader
 include(dr("api/endpoint.php"));
+include(dr('util.php'));
+include(dr('db/auth.php'));
 
 use Lcobucci\JWT;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 
 class AuthApiEndpoint implements ApiEndpoint {
   public function act($path, array $named_args, $query_string) {
-    // TODO: need to swap our stuff to an autoloader
-    include(dr('config.php'));
-    include(dr('util.php'));
-    include(dr('db/auth.php'));
-
     $db = get_db();
 
     $req = _getBodyJSON();
     $user = $req['username'];
     $pass = $req['password'];
 
-    $r = get_user($db, $user);
+    $r = get_user_for_auth($db, $user);
+
 
     $authed = false;
 

--- a/www/api/auth.php
+++ b/www/api/auth.php
@@ -7,7 +7,6 @@ use Lcobucci\JWT\Signer\Hmac\Sha256;
 class AuthApiEndpoint implements ApiEndpoint {
   public function act($path, array $named_args, $query_string) {
     // TODO: need to swap our stuff to an autoloader
-    include(dr('db/query_result.php'));
     include(dr('config.php'));
     include(dr('util.php'));
     include(dr('db/auth.php'));

--- a/www/api/endpoint.php
+++ b/www/api/endpoint.php
@@ -11,6 +11,10 @@ interface ApiEndpoint {
 // AuthedApiEndpoint is base class that handles request authentication by
 // validating a JWT header and ensuring it comes with a claim that indicates
 // the requesting user's ID. Once Authentication is done authed_action is called.
+//
+// NOTE: This base class handles _authentication_ and does not make any claims
+// about whether or not the user is authorized to take the action. That should
+// be verify by the endpoint itself.
 abstract class AuthedApiEndpoint implements ApiEndpoint {
   // authed_action will only be called if the request is made with a valid JWT
   abstract protected function authed_action($user_id, $path, array $named_args, $query_string);

--- a/www/api/get_devices.php
+++ b/www/api/get_devices.php
@@ -1,0 +1,41 @@
+<?php
+include(dr("api/endpoint.php"));
+include(dr("util.php"));
+include(dr("db/auth.php"));
+include(dr("db/devices.php"));
+
+class GetDevicesApiEndpoint extends AuthedApiEndpoint implements ApiEndpoint {
+  protected function authed_action($id, $path, array $path_args, $query_string) {
+    if (!isset($path_args["user"])) {
+      return bad_endpoint($path);
+    }
+
+    $db = get_db();
+    $email = $path_args["user"];
+    $result = has_email($db, $id, $email, $this->not_authed($path));
+
+    return $result->map(function($data) use ($db, $id) {
+      return get_devices($db, $id)->process(
+        function($query_result) {
+          $device_data = [];
+
+          while ($row = $query_result->row()) {
+            $device_data[] = [
+              "device_id" => $row["device_id"],
+              "device_type_id" => $row["device_type_id"],
+              "device_type_name" => $row["name"],
+              "group_id" => $row["group_id"]
+            ];
+          }
+          return new ApiSuccess(["devices" => $device_data]);
+        },
+
+        function($err) {
+          return internal_server_error($err); 
+        }
+      );
+    })->get();
+  }
+}
+
+?>

--- a/www/api/new_device.php
+++ b/www/api/new_device.php
@@ -1,13 +1,29 @@
 <?php
 include(dr("api/endpoint.php"));
+include(dr("util.php"));
+include(dr("db/auth.php"));
+include(dr("db/devices.php"));
 
 class NewDeviceApiEndpoint extends AuthedApiEndpoint implements ApiEndpoint {
-  protected function authed_action($id, $path, array $named_args, $query_string) {
-    return new ApiError([
-      "short" => "NOT IMPLEMENTED",
-      "args" => $named_args,
-      "qs" => $query_string
-    ], 501);
+  protected function authed_action($id, $path, array $path_args, $query_string) {
+    if (!isset($path_args["user"])) {
+      return bad_endpoint($path);
+    }
+
+    $db = get_db();
+    $email = $path_args["user"];
+    $result = has_email($db, $id, $email, $this->not_authed($path));
+
+    return $result->map(function($data) use ($db, $id) {
+      return create_vehicle($db, $id)->process(
+        function($dev_id) {
+          return new ApiSuccess(["device_id" => $dev_id]);
+        },
+        function($err) {
+          return internal_server_error();
+        }
+      );
+    })->get();
   }
 }
 

--- a/www/api/new_device.php
+++ b/www/api/new_device.php
@@ -20,7 +20,7 @@ class NewDeviceApiEndpoint extends AuthedApiEndpoint implements ApiEndpoint {
           return new ApiSuccess(["device_id" => $dev_id]);
         },
         function($err) {
-          return internal_server_error();
+          return internal_server_error($err);
         }
       );
     })->get();

--- a/www/api/new_device.php
+++ b/www/api/new_device.php
@@ -1,0 +1,14 @@
+<?php
+include(dr("api/endpoint.php"));
+
+class NewDeviceApiEndpoint extends AuthedApiEndpoint implements ApiEndpoint {
+  protected function authed_action($id, $path, array $named_args, $query_string) {
+    return new ApiError([
+      "short" => "NOT IMPLEMENTED",
+      "args" => $named_args,
+      "qs" => $query_string
+    ], 501);
+  }
+}
+
+?>

--- a/www/core.php
+++ b/www/core.php
@@ -66,6 +66,10 @@ function _camel($s) {
   return str_replace(' ', '', ucwords(str_replace('_', ' ', $s)));
 }
 
+function _canonicalize($s) {
+  return strtolower($s);
+}
+
 function find_gping_lib($name) {
   if (strpos($name, "GPing\\") !== 0) {
     return false;

--- a/www/core.php
+++ b/www/core.php
@@ -4,6 +4,10 @@ function dr($p) {
   return $_SERVER["DOCUMENT_ROOT"] . "/$p";
 }
 
+function lib($p) {
+  return dr("lib/$p");
+}
+
 // TODO: remove usage of this
 function load($name) {
   require_once($_SERVER["DOCUMENT_ROOT"] . "/$name");
@@ -61,4 +65,25 @@ function _snake($s) {
 function _camel($s) {
   return str_replace(' ', '', ucwords(str_replace('_', ' ', $s)));
 }
+
+function find_gping_lib($name) {
+  if (strpos($name, "GPing\\") !== 0) {
+    return false;
+  }
+
+  $pcs = explode('\\', $name);
+
+  // drop GPing
+  array_shift($pcs);
+  // put remainder in canonical format
+  for ($i = 0; $i < count($pcs); $i++) {
+    $pcs[$i] = _snake($pcs[$i]);
+  }
+
+  // and construct the path!
+  $path = implode(DIRECTORY_SEPARATOR, $pcs);
+  include(lib("$path.php"));
+}
+
+spl_autoload_register(find_gping_lib);
 ?>

--- a/www/db/auth.php
+++ b/www/db/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use GPing\DB;
+
 function get_user($db, $email) {
   $email = mysql_real_escape_string($email);
   $query = <<<QUERY
@@ -12,7 +14,7 @@ WHERE
 LIMIT 1;
 QUERY;
 
-  return new QueryResult($db, mysql_query($query, $db));
+  return new DB\QueryResult($db, mysql_query($query, $db));
 }
 
 ?>

--- a/www/db/auth.php
+++ b/www/db/auth.php
@@ -2,7 +2,7 @@
 
 use GPing\DB;
 
-function get_user($db, $email) {
+function get_user_for_auth($db, $email) {
   $email = mysql_real_escape_string($email);
   $query = <<<QUERY
 SELECT
@@ -17,4 +17,18 @@ QUERY;
   return new DB\QueryResult($db, mysql_query($query, $db));
 }
 
+function get_user_by_id($db, $id) {
+  $id = (int)$id;
+  $query = <<<QUERY
+SELECT
+  id, email
+FROM
+  login_data
+WHERE
+  id = $id
+LIMIT 1;
+QUERY;
+
+  return new DB\QueryResult($db, mysql_query($query, $db));
+}
 ?>

--- a/www/db/db_read.php
+++ b/www/db/db_read.php
@@ -1,7 +1,8 @@
 <?php
 require_once($_SERVER["DOCUMENT_ROOT"] . '/core.php');
-require_once(dr('db/query_result.php'));
 load('db/db.php');
+
+use GPing\DB;
 
 function _readTrackingTable($id, $table, $limit = 120) {
   global $db;
@@ -23,7 +24,7 @@ WHERE ${id_clause} AND lat > 0
 ORDER BY t DESC LIMIT ${limit}
 QUERY;
 
-  return new QueryResult($db, mysql_query($sql, $db));
+  return new DB\QueryResult($db, mysql_query($sql, $db));
 }
 
 function readGPSHistory($id, $limit = 120) {
@@ -51,7 +52,7 @@ ORDER BY gping.t desc
 LIMIT 1
 QUERY;
 
-  return new QueryResult($db, mysql_query($sql, $db));
+  return new DB\QueryResult($db, mysql_query($sql, $db));
 }
 
 function readVoltage($id, $limit = 120) {
@@ -70,7 +71,7 @@ ORDER BY gping.t DESC
 LIMIT $limit
 QUERY;
 
-  return new QueryResult($db, mysql_query($sql, $db));
+  return new DB\QueryResult($db, mysql_query($sql, $db));
 }
 
 

--- a/www/db/devices.php
+++ b/www/db/devices.php
@@ -1,0 +1,28 @@
+<?php
+
+use GPing\Success;
+use GPing\Failure;
+use GPing\DB;
+
+function create_device($db, $user_id, $device_type) {
+  $id = generateRandomString(12);
+
+  $query = <<<QUERY
+INSERT INTO user_devices(device_id, user_id, device_type_id) VALUES
+  ('$id', $user_id, $device_type);
+QUERY;
+
+  if (!mysql_query($query)) {
+    return new Failure(mysql_error());
+  }
+
+  return new Success($id);
+}
+
+// create_vehicle adds a new vehicle type for the specified $user_id. On success
+// a GPing\Success is returned with the new device id. Otherwise a GPing\Failure
+// is returned with the db error.
+function create_vehicle($db, $user_id) {
+  return create_device($db, $user_id, 1);
+}
+?>

--- a/www/db/devices.php
+++ b/www/db/devices.php
@@ -25,4 +25,28 @@ QUERY;
 function create_vehicle($db, $user_id) {
   return create_device($db, $user_id, 1);
 }
+
+// get_devices returns all devices known for the specified user. On success a
+// GPing\Success(GPing\DB\QueryResult) is returned. On failure a GPing\Failure
+// is returned with the error pulled from the mysql_query call.
+function get_devices($db, $user_id) {
+  $query = <<<QUERY
+SELECT
+  d.device_id, d.device_type_id, dt.name, d.group_id
+FROM
+  user_devices d,
+  device_type dt
+WHERE
+  d.device_type_id = dt.device_type_id
+;
+QUERY;
+
+  $result = new DB\QueryResult($db, mysql_query($query, $db));
+
+  if ($result->err()) {
+    return new Failure($result->err());
+  } else {
+    return new Success($result);
+  }
+}
 ?>

--- a/www/lib/attempt.php
+++ b/www/lib/attempt.php
@@ -1,0 +1,81 @@
+<?php
+namespace GPing;
+
+interface Attempt {
+  // isSuccess returns true if this Attempt is a Success
+  public function isSuccess();
+
+  // isSuccess returns true if this Attempt is a Failure
+  public function isFailure();
+
+  // get returns either the value kept as part of the success _or_ the error
+  // which caused escalation to Failure
+  public function get();
+
+  // map takes a fuction which accepts the result of a Success and produces
+  // some new result. That result is then returned as a Success of its own.
+  // If calling the function throws (note: not returns) an Exception it is
+  // converted into a Failure.
+  //
+  // If map is called on a Failure the Failure is returned and the function is
+  // not called. This enables chains of code to be written ensuring progress
+  // in made only when previous steps have completed without Exception.
+  //
+  // Example:
+  //
+  //   function auth() {
+  //     // do auth
+  //     if ($could_not_auth) {
+  //       throw new AuthenticationFailedException(...);
+  //     } else {
+  //       return AuthenticatedUser(...);
+  //     }
+  //   }
+  //
+  //   function perform_request($user) {
+  //     // do things that must be protected
+  //     return $request_result;
+  //   }
+  //
+  //   $result = auth()->map(perform_request);
+  //     auth() will attempte to authenticate the user and will either
+  //     1. succeed - perform_request will get called with $user being set
+  //        as the AuthenticatedUser constructed and returned from auth
+  //     2. fail by throwing an AuthenticationFailedException - this results
+  //        in perform_request no getting called because map on a Failure
+  //        only returns the Failure.
+  //     $result will be either Success($request_result) or Failure(AuthenticationFailedException(...))
+  public function map(callable $fn);
+
+  // flatMap takes a callable function which accepts the result of a Success
+  // and produces a new Attempt. The result of that callable is then flattened
+  // so that we don't end up with Success(Success(Success(42))) etc. This
+  // allows users to more easily handle deeply nested call chains without
+  // having to unpack them to determine if the result was eventually success
+  // or failure.
+  //
+  // This path is also useful if you wish to indicate Failure in ways other than
+  // throwing Exceptions.
+  //
+  // Example:
+  //
+  //   function foo()   { return new Success(42); }
+  //   function bar($n) { return new Success("number " . $n); }
+  //   function err()   { return new Failure(new Exception("bad code")); }
+  //   foo()->map(bar)      // produces "number 42"
+  //   foo()->map(err)      // produces Success(Failure("bad code"))
+  //   foo()->flatMap(err); // produces Failure("bad code"))
+  public function flatMap(callable $tryFn);
+
+  // process makes acting on succes or failure simple. It takes two callables
+  // which will be be passed either the result of a Success or the error nested
+  // within a Failure.
+  //
+  // The return value from the parameter function is passed back directly (i.e.
+  // not wrapped in a Success/Failure).
+  public function process(callable $succFn, callable $failFn);
+}
+
+// With deepest and most sincere apologies to com.twitter.util.Try <3.
+
+?>

--- a/www/lib/base.php
+++ b/www/lib/base.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace GPing;
+
+abstract class Base implements Attempt {
+  public function map(callable $fn) {
+    if ($this->isFailure()) {
+      return $this;
+    }
+
+    try {
+      return new Success($fn($this->get()));
+    } catch (Exception $e) {
+      return new Failure($e);
+    }
+  }
+
+  public function flatMap(callable $fn /* $data -> Attempt */) {
+    $result = $this->map($fn);
+
+    // if it's a failure there isn't anything to unwrap
+    if ($result->isFailure()) {
+      return $result;
+    }
+
+    // in the success case we should expect the contents to be another
+    // attempt that we are going to unwrap
+    $v = $result->get();
+    if ($v instanceof Success) {
+      return new Success($v->get());
+    }
+    if ($v instanceof Failure) {
+      return $v;
+    }
+
+    throw new \Exception("unexpected result " . var_dump($v) . " in flatMap");
+  }
+
+  public function process(callable $succFn, callable $failFn) {
+    if ($this->isSuccess()) {
+      return $succFn($this->get());
+    }
+
+    if ($this->isFailure()) {
+      return $failFn($this->get());
+    }
+  }
+}
+
+?>

--- a/www/lib/db/query_result.php
+++ b/www/lib/db/query_result.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GPing\DB;
+
+// QueryResult is a trivial container for interacting with DB results.
+class QueryResult {
+  private $error;
+  private $result;
+  private $num_rows;
+
+  function __construct($db, $result) {
+    $this->result = $result;
+    $this->error = mysql_error($db);
+
+    if ($result) {
+      $this->num_rows = mysql_num_rows($result);
+    } else {
+      $this->num_rows = 0;
+    }
+  }
+
+  function count() {
+    return $this->num_rows;
+  }
+
+  function row() {
+    $next = mysql_fetch_assoc($this->result);
+    // I don't actually know if mysql_fetch_assoc can set mysql_error... *shrug*
+    $this->error = mysql_error();
+    return $next;
+  }
+
+  function err() {
+    return $this->error;
+  }
+}
+
+?>

--- a/www/lib/failure.php
+++ b/www/lib/failure.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GPing;
+
+class Failure extends Base {
+  private $ex;
+
+  public function __construct($ex) {
+    $this->ex = $ex;
+  }
+
+  public function isSuccess() { return false; }
+  public function isFailure() { return true; }
+  public function get() { return $this->ex; }
+}
+
+?>

--- a/www/lib/success.php
+++ b/www/lib/success.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GPing;
+
+class Success extends Base {
+  private $value;
+
+  public function __construct($v = null) {
+    $this->value = $v;
+  }
+
+  public function isSuccess() { return true; }
+  public function isFailure() { return false; }
+  public function get() { return $this->value; }
+}
+
+?>


### PR DESCRIPTION
Small changes, progress, and intellectual dishonesty.

## Small Changes

- Introduced a `lib/` directory (c.f. #27) to store `GPing\` code and added an autoloader; moved `DB\QueryResult` into it
- Moved 403 & 503 `Response` construction into functions

## Progress

Implemented two new endpoints: `POST /v1/<user>/device` and `GET /v1/<user>/devices` which create and list user devices that may be constructed to post positional data.

## Intellectual Dishonesty

Pretended that PHP is a more rigorous language than it is (hoping that without type checking this doesn't collapse on itself) and introduced v0.1 of `Attempt` which is effectively a `scala.util.Try` or `Either` to make representing chains of actions easier when we mostly just care that the first error results in failure.

fixes #24 
