### PR TITLE
Adds test to verify signin endpoint doesn't break

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Our community guidelines are outlined in the [code of conduct][conduct].
 - [Roadmap][roadmap]&mdash;Where we see GPing going and the large blocks of
   work that needs attention next.
 - [Issues List][issues]&mdash;actionable tasks that need to be completed to
-  reach some goal on our roadmap.
+  reach some goal on our roadmap. Items marked with `help wanted` should be
+  reasonable tasks to get involved with when you're new to the project.
 - [Forum][gg]&mdash;Ask questions to the community.
 
 We also try to idle in the `#gping.io` IRC channel on [Freenode][fn].

--- a/docker/README.md
+++ b/docker/README.md
@@ -60,9 +60,10 @@ A few scripts exist to make life a bit easier:
 - `docker/db.sh`&mdash;starts an instance of a dev database using the default
    configurations from `docker/db/env`.
 - `docker/shell.sh`&mdash;starts a shell in the specified docker container.
-- `docker/www.sh`&mdashstarts an instance of the `gping.io` website with
+- `docker/www.sh`&mdash;starts an instance of the `gping.io` website with
    routing to a dev database using default configurations in `docker/www/env`
    and the `live` tag by default.
+- `docker/test.sh`&mdash;runs unit tests under the `tests` directory.
 
 ### Environment Variables
 

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ -z $GPINGIO_HOME ]; then
+  echo GPINGIO_HOME must be set
+  exit 1
+fi
+
+LOGDIR=$GPINGIO_HOME/.logs
+LOGFILE=$LOGDIR/www-tests
+
+rm -f $LOGFILE
+
+echo "Checking for 'www' container."
+if [ ! `docker ps -f name=www | wc -l` == "2" ]; then
+  echo "  Did not find container, attempting to start."
+  $GPINGIO_HOME/docker/www.sh > $LOGFILE 2>&1
+  RESULT=$?
+  if [ ! $RESULT == 0 ]; then
+    echo "  Failed to start www container."
+    echo
+    cat $LOGFILE
+    exit 1
+  fi
+fi
+
+echo "Running tests"
+echo
+
+docker exec www /bin/bash -c "\
+  cd /root/test; \
+  phpunit --testdox-text /root/test/results.txt > /root/test/runlog.txt 2>&1; \
+  cat /root/test/results.txt"
+
+echo >> $LOGFILE
+cat $GPINGIO_HOME/test/runlog.txt >> $LOGFILE
+rm -f $GPINGIO_HOME/test/runlog.txt
+mv $GPINGIO_HOME/test/results.txt $LOGDIR
+
+echo
+echo "Completed running unit tests."
+echo "  Execution log: $LOGFILE"
+echo "  Results:       $LOGDIR/results.txt"

--- a/docker/www/live.Dockerfile
+++ b/docker/www/live.Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -y install zlib1g-dev
 RUN apt-get -y install ssh
 RUN apt-get -y install phpunit
 RUN apt-get -y install locate
+
 RUN updatedb
 
 COPY docker/www/install-composer.sh /root/install-composer.sh
@@ -27,3 +28,7 @@ RUN docker-php-ext-install mysql
 RUN docker-php-ext-install zip
 
 COPY docker/www/php.ini /usr/local/etc/php/
+
+# Things for test / live instances only can be placed below this so that all
+# the above commands generate a cache usable by the the prod image build process.
+RUN apt-get -y install php5-curl

--- a/test/api/common.php
+++ b/test/api/common.php
@@ -1,0 +1,119 @@
+<?php
+  use GPing\Attempt;
+  use GPing\Success;
+  use GPing\Failure;
+
+  include_once(__DIR__ . "/fixtures.php");
+
+  // Supported opts keys:
+  //   data - data that should be included in the body
+  //   headers - array of header strings in the format ["HeaderName: Value", "HeaderName2: Value2"]
+  function default_opts(array $opts = null) {
+    if ($opts == null) {
+      $opts = [];
+    }
+
+    $keys = [
+      "data",
+      "headers"
+    ];
+
+    foreach ($keys as $k) {
+      if (!array_key_exists($k, $opts)) {
+        $opts[$k] = null;
+      }
+    }
+
+    return $opts;
+  }
+
+  function post_encode($url, array $data, array $opts = null) {
+    $data = json_encode($data);
+    return post($url, $data);
+  }
+
+  function post($url, $data, array $opts = null) {
+    $opts['data'] = $data;
+    return _req(CURLOPT_POST, $url, $opts);
+  }
+
+  function get($url, array $opts = null) {
+    return _req(CURLOPT_HTTPGET, $url, $opts);
+  }
+
+  function _req($typ, $url, array $opts = null) {
+    $opts = default_opts($opts);
+    $data = $opts["data"];
+    $headers = $opts["headers"];
+
+    $resource = curl_init("http://localhost:80/$url");
+    curl_setopt($resource, $typ, TRUE);
+    if ($data != null) {
+      curl_setopt($resource, CURLOPT_POSTFIELDS, $data);
+    }
+    if ($headers != null) {
+      curl_setopt($resource, CURLOPT_HTTPHEADER, $headers);
+    }
+    curl_setopt($resource, CURLOPT_RETURNTRANSFER, TRUE); 
+    $response = curl_exec($resource);
+
+    $result = null;
+    if (!$response) {
+      $result = new Failure(curl_error($resource));
+    } else {
+      $code = curl_getinfo($resource, CURLINFO_HTTP_CODE);
+      $result = new Success([$code, $response]);
+    }
+    curl_close($resource);
+
+    return $result;
+  }
+
+  function api_okay(Attempt $req_response, $test, $want_code = 200) {
+    if ($req_response->isFailure()) {
+      $test->assertTrue(false);
+      return new Failure();
+    }
+
+      return $req_response->map(function($r) use ($test, $want_code) {
+          $code = $r[0];
+          $body = $r[1];
+
+          $test->assertEquals($want_code, $code);
+          $test->assertNotEmpty($body);
+
+          $o = json_decode($body);
+          $r[] = $o;
+          $test->assertNotNull($o);
+
+          $test->assertEquals("ok", $o->status);
+          $test->assertNull($o->error);
+
+          return $r;
+      });
+  }
+
+  function api_error(Attempt $req_response, $test, $want_code = 500) {
+    if ($req_response->isFailure()) {
+      $test->assertTrue(false);
+      return new Failure();
+    }
+
+    return $req_response->map(function($r) use ($test, $want_code) {
+      $code = $r[0];
+      $body = $r[1];
+
+      $test->assertEquals($want_code, $code);
+      $test->assertNotEmpty($body);
+
+      $o = json_decode($body);
+      $r[] = $o;
+      $test->assertNotNull($o);
+
+      $test->assertEquals("error", $o->status);
+      $test->assertNotNull($o->error);
+
+      return $r;
+    });
+  }
+?>

--- a/test/api/fixtures.php
+++ b/test/api/fixtures.php
@@ -1,0 +1,5 @@
+<?php
+  class Fixtures {
+    public static $user1_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJncGluZy5pbyIsImF1ZCI6ImdwaW5nLmlvIiwiaWF0IjoxNDgzODQyMTIzLCJ1aWQiOiIxIn0.PDyLJOwvOJT3jEEfJY860RHWCfW1-J1W1vW4fUdCipM";
+  }
+?>

--- a/test/api/ping_test.php
+++ b/test/api/ping_test.php
@@ -1,0 +1,29 @@
+<?php
+
+$_SERVER = Array();
+$_SERVER["DOCUMENT_ROOT"] = "/var/www/html";
+
+require_once "PHPUnit/Autoload.php";
+require_once "/var/www/html/core.php";
+require_once "/var/www/html/api/ping.php";
+require_once "/var/www/html/api/envelope.php";
+
+class api_ping_test extends PHPUnit_Framework_TestCase {
+
+  public function test_ping() {
+    $ping = new PingApiEndpoint();
+    $response = $ping->act("/",Array(),"");
+    $this->assertEquals($response->getPayload(),"pong");
+    $this->assertTrue($response->isSuccess());
+  }
+
+  public function test_ping_api() {
+    $json = file_get_contents("http://localhost:80/api/v1/ping");
+    $o = json_decode($json);
+    $this->assertEquals($o->status,"ok");
+    $this->assertNull($o->error);
+    $this->assertEquals($o->data, "pong");
+  }
+}
+
+?>

--- a/test/api/signin_test.php
+++ b/test/api/signin_test.php
@@ -1,0 +1,70 @@
+<?php
+
+$_SERVER = Array();
+$_SERVER["DOCUMENT_ROOT"] = "/var/www/html";
+
+require_once "PHPUnit/Autoload.php";
+require_once $_SERVER["DOCUMENT_ROOT"] . "/core.php";
+require_once __DIR__ . "/common.php";
+
+class api_signin_test extends PHPUnit_Framework_TestCase {
+  public function test_success() {
+    $resp = post_encode("api/v1/signin", [
+      "username" => "user1@example.com",
+      "password" => "user1-password"
+    ]);
+
+    $t = $this;
+    api_okay($resp, $this)->map(function($r) use ($t) {
+      $o = $r[2];
+      $t->assertNotEmpty($o->data->token);
+    });
+  }
+
+  public function test_bad_password() {
+    $resp = post_encode("api/v1/signin", [
+      "username" => "user1@example.com",
+      "password" => "bad-password"
+    ]);
+
+    $t = $this;
+    api_error($resp, $this, 403)->map(function($r) use ($t) {
+      $o = $r[2];
+      $t->assertEmpty($o->data);
+    });
+  }
+
+  public function test_no_user() {
+    $resp = post_encode("api/v1/signin", [
+      "password" => "user1-password"
+    ]);
+
+    $t = $this;
+    api_error($resp, $this, 403)->map(function($r) use ($t) {
+      $o = $r[2];
+      $t->assertEmpty($o->data);
+    });
+  }
+
+  public function test_bad_post_data() {
+    $resp = post("api/v1/signin", "[asoentuh");
+
+    $t = $this;
+    api_error($resp, $this, 403)->map(function($r) use ($t) {
+      $o = $r[2];
+      $t->assertEmpty($o->data);
+    });
+  }
+
+  public function test_http_get() {
+    $resp = get("api/v1/signin");
+
+    $t = $this;
+    api_error($resp, $this, 405)->map(function($r) use ($t) {
+      $o = $r[2];
+      $t->assertEmpty($o->data);
+    });
+  }
+}
+
+?>

--- a/test/api/verify_test.php
+++ b/test/api/verify_test.php
@@ -1,0 +1,36 @@
+<?php
+
+$_SERVER = Array();
+$_SERVER["DOCUMENT_ROOT"] = "/var/www/html";
+
+require_once "PHPUnit/Autoload.php";
+require_once $_SERVER["DOCUMENT_ROOT"] . "/core.php";
+require_once __DIR__ . "/common.php";
+
+class api_verify_signin_test extends PHPUnit_Framework_TestCase {
+  public function test_success() {
+    $resp = get("api/v1/verify", [
+      "data" => null,
+      "headers" => ["Authorization: " . Fixtures::$user1_token]
+    ]);
+
+    api_okay($resp, $this);
+  }
+
+  public function test_bad_token() {
+    $resp = get("api/v1/verify", [
+      "data" => null,
+      "headers" => ["Authorization: bad_token"]
+    ]);
+
+    api_error($resp, $this, 403);
+  }
+
+  public function test_no_token() {
+    $resp = get("api/v1/verify");
+
+    api_error($resp, $this, 403);
+  }
+}
+
+?>

--- a/test/ping_test.php
+++ b/test/ping_test.php
@@ -1,27 +1,18 @@
 <?php
 
-$_SERVER = Array(); 
+$_SERVER = Array();
 $_SERVER["DOCUMENT_ROOT"] = "/var/www/html";
 
 require_once "PHPUnit/Autoload.php";
-require_once "/var/www/html/core.php";
-require_once "/var/www/html/api/ping.php";
-require_once "/var/www/html/api/envelope.php";
 
 class ping_test extends PHPUnit_Framework_TestCase {
-  
-  public function test_ping() {
-    $ping = new PingApiEndpoint();
-    $response = $ping->act("/",Array(),"");
-    $this->assertEquals($response->getPayload(),"pong");
-    $this->assertTrue($response->isSuccess());
-  } 
 
   public function test_ping_api() {
     $json = file_get_contents("http://localhost:80/ping?ver=1");
     $o = json_decode($json);
     $this->assertEquals($o->result,"ok");
     $this->assertEquals(strlen($o->id),12);
-  } 
-        
+  }
 }
+
+?>

--- a/www/api-route.php
+++ b/www/api-route.php
@@ -1,5 +1,6 @@
 <?php
   include($_SERVER["DOCUMENT_ROOT"] . "/core.php");
+  include(dr('config.php'));
   include(dr('api/envelope.php'));
   include(dr('api-logger.php'));
 

--- a/www/api/endpoint.php
+++ b/www/api/endpoint.php
@@ -1,5 +1,4 @@
 <?php
-include(dr('config.php'));
 
 use GPing\Success;
 use GPing\Failure;

--- a/www/core.php
+++ b/www/core.php
@@ -89,5 +89,5 @@ function find_gping_lib($name) {
   include(lib("$path.php"));
 }
 
-spl_autoload_register(find_gping_lib);
+spl_autoload_register('find_gping_lib');
 ?>


### PR DESCRIPTION
Pretty straight forward. Uses the `GPing\Attempt` so it's based on `falun/device-registration` and shouldn't be merged until that goes in and this can be rebased to `master`.